### PR TITLE
Web: Update jsfiddle so it uses latest SDK with a fix for Live Data Position.

### DIFF
--- a/src/web/v4/getting-started/livedata.md
+++ b/src/web/v4/getting-started/livedata.md
@@ -173,7 +173,7 @@ Learn more about controlling and rendering Live Data in MapsIndoors in the [intr
 <mi-tab label="Manually" tab-for="manually"></mi-tab>
 <mi-tab label="MI Components" tab-for="components"></mi-tab>
   <mi-tab-panel id="manually">
-  <iframe width="100%" src="//jsfiddle.net/simonlaustsen/3z9tby8q/37/embedded/js,html,result/" frameborder="0"></iframe>
+  <iframe width="100%" src="//jsfiddle.net/simonlaustsen/3z9tby8q/48/embedded/js,html,result/" frameborder="0"></iframe>
   </mi-tab-panel>
 
   <mi-tab-panel id="components">


### PR DESCRIPTION
Update jsfiddle so it uses latest SDK with a fix for Live Data Position.

The current JSFiddle uses SDK 4.5.x, which contains a bug regarding live data. A new version of the fiddle is made, which uses a version of the SDK where the bug is fixed.