### PR TITLE
Update/fix to new getting started

### DIFF
--- a/src/_includes/header.njk
+++ b/src/_includes/header.njk
@@ -76,4 +76,7 @@
     <a href="https://github.com/mapspeople">GitHub</a>
     <a href="https://blog.mapspeople.com/tag/product">Product Blog</a>
     <a href="https://cms.mapsindoors.com">CMS</a>
+    <a href="https://app.mapsindoors.com/mapsindoors/reference/ios/v3/classes.html">Reference Docs - iOS</a>
+    <a href="https://app.mapsindoors.com/mapsindoors/reference/android/v3/index.html">Reference Docs - Android</a>
+    <a href="https://app.mapsindoors.com/mapsindoors/js/sdk/latest/docs/index.html">Reference Docs - Web</a>
 </div>

--- a/src/getting-started/android/next-step.md
+++ b/src/getting-started/android/next-step.md
@@ -1,0 +1,10 @@
+---
+title: The Next Step...
+layout: redirect
+destination: /android/v3/
+eleventyNavigation:
+  title: The Next Step...
+  key: getting-started-android-nextstep
+  parent: getting-started-android
+  order: 180
+---

--- a/src/getting-started/ios/live-data.md
+++ b/src/getting-started/ios/live-data.md
@@ -36,3 +36,6 @@ Assuming the demo key is utilising you should now see a "Staff Person" moving fr
 ![Expected Result](/assets/ios/getting-started/er_live-data.gif)
 
 Learn more about about controlling and rendering Live Data in MapsIndoors in the [introducion to Live Data](http://0.0.0.0:8080/ios/v3/guides/live-data/)
+
+<!-- Congrats -->
+{% include "src/shared/getting-started/congrats.md" %}

--- a/src/getting-started/ios/next-step.md
+++ b/src/getting-started/ios/next-step.md
@@ -1,0 +1,10 @@
+---
+title: The Next Step...
+layout: redirect
+destination: /ios/v3/
+eleventyNavigation:
+  title: The Next Step...
+  key: getting-started-ios-nextstep
+  parent: getting-started-ios
+  order: 180
+---

--- a/src/getting-started/web/next-step.md
+++ b/src/getting-started/web/next-step.md
@@ -1,0 +1,10 @@
+---
+title: The Next Step...
+layout: redirect
+destination: /web/v4/
+eleventyNavigation:
+  title: The Next Step...
+  key: getting-started-web-nextstep
+  parent: getting-started-web
+  order: 180
+---

--- a/src/shared/getting-started/congrats.md
+++ b/src/shared/getting-started/congrats.md
@@ -8,4 +8,4 @@ Congratulations! You're at the end of your journey (for now), and you've accompl
 * You added functionality for getting directions from one Location to another.
 * You learned how to enable different types of Live Data Domains in your app.
 
-This concludes the "Getting Started" tutorial, but there's always more to discover. To get more inspiration on what to build next please visit our [showcase page](https://www.mapspeople.com/showcases) to see how other clients use MapsIndoors!
+This concludes the "Getting Started" tutorial, but there's always more to discover. To get more inspiration on what to build next please visit our [showcase page](https://www.mapspeople.com/showcases) to see how other clients use MapsIndoors! For more documentation, please visit the rest of our Docs site for [Android](/android/v3/), [iOS](/ios/v3/) and [Web](/web/v4/).


### PR DESCRIPTION
Did the following to address concerns after update:

- Added links to reference docs to Header. It might seem a little cluttered though, so might do a different solution in the future. But it works for now.
- Added a "The Next Step..." file for each Getting Started section, that redirects to the relevant "proper" guides section.
- Added the "Congrats" summary to the iOS guide, it was missing for some reason.
- Added links to further guides to the "Congrats" summary as well.