### PR TITLE
updated footer to include Changelog subheaders

### DIFF
--- a/src/_includes/footer.njk
+++ b/src/_includes/footer.njk
@@ -114,6 +114,13 @@
     <h2>
       <a href="/changelogs/">Changelogs</a>
     </h2>
+    <ul class="list">
+      {% set changelogs = collections.published | eleventyNavigation("changelogs") %}
+      {%- for entry in changelogs %}
+        {{ renderNavListItem(entry) }}
+      {%- endfor -%}
+    </ul>
+    </h2>
     <h2>
       <a href="/product/">Product Overview</a>
     </h2>


### PR DESCRIPTION
Very simple edit, I was asked to ensure that the subheaders for the Changelog were visible in the footer. When restructured website goes online we'll remove some of the legacy versions.