### PR TITLE
Add missing and required parameter to directions guide for Web.

### DIFF
--- a/src/getting-started/web/directions.md
+++ b/src/getting-started/web/directions.md
@@ -146,7 +146,7 @@ const mapViewInstance = new mapsindoors.mapView.MapboxView(mapViewOptions);
 const mapsIndoorsInstance = new mapsindoors.MapsIndoors({ mapView: mapViewInstance });
 const mapboxInstance = mapViewInstance.getMap();
 
-+ const externalDirectionsProvider = new mapsindoors.directions.MapboxProvider();
++ const externalDirectionsProvider = new mapsindoors.directions.MapboxProvider('YOUR_MAPBOX_ACCESS_TOKEN');
 + const miDirectionsServiceInstance = new mapsindoors.services.DirectionsService(externalDirectionsProvider);
 + const directionsRendererOptions = { mapsIndoors: mapsIndoorsInstance }
 + const miDirectionsRendererInstance = new mapsindoors.directions.DirectionsRenderer(directionsRendererOptions);


### PR DESCRIPTION
Bugfix for: The Getting Started Guide on Directions for Web lacks a required parameter in the example code.

@JG1995 Not sure what branch to point this towards. I'll leave that up to you to change.

