### PR TITLE
Feature/am/miajs 1667 collapsible sidebar menu

### DIFF
--- a/src/_includes/head.njk
+++ b/src/_includes/head.njk
@@ -19,6 +19,7 @@
         />
         <link rel="stylesheet" href="{{ '/assets/syntax-theme.css' | url }}" />
 
+        <script src="{{ '/assets/sidebar.js' | url }}"></script>
         <script
             type="module"
             src="https://unpkg.com/@mapsindoors/components@7.2.1/dist/mi-components/mi-components.esm.js"

--- a/src/_includes/sidebar.njk
+++ b/src/_includes/sidebar.njk
@@ -53,34 +53,3 @@
   {% endif %}
   {{ navPages | eleventyNavigationToHtml({listClass: "sidebar-nav", activeListItemClass: "active", activeKey: eleventyNavigation.key}) | safe }}
 </nav>
-
-<script>
-
-/*
- * Step 1: Hide elements in the sidebar that is unrelated to the currently shown page (marked with class name "active").
- */
-let activeListItem = document.querySelector('.sidebar-nav .active');
-if (activeListItem) {
-  activeListItem.querySelector(':scope > ul') ? activeListItem.querySelector(':scope > ul').style.display = 'block' : null;
-
-  // Traverse updwards from the active and show lists
-  while (activeListItem.parentNode && activeListItem.parentNode.classList.contains('sidebar-nav') === false) {
-    activeListItem = activeListItem.parentNode;
-    if (activeListItem.tagName = 'li') {
-      activeListItem.classList.add('visible');
-    }
-  }
-} else {
-  document.querySelector('.sidebar-nav > li > ul').style.display = 'block';
-}
-
-/*
- * Step 2: Decorate menu items that have children with an indicator
- */
-const collapsibleMenuItems = document.querySelectorAll('.sidebar-nav a + ul');
-collapsibleMenuItems.forEach(node => {
-  if (node.previousElementSibling) {
-    node.previousElementSibling.insertAdjacentHTML('beforeend', ' &raquo;');
-  }
-});
-</script>

--- a/src/_includes/sidebar.njk
+++ b/src/_includes/sidebar.njk
@@ -54,16 +54,6 @@
   {{ navPages | eleventyNavigationToHtml({listClass: "sidebar-nav", activeListItemClass: "active", activeKey: eleventyNavigation.key}) | safe }}
 </nav>
 
-<style>
-    .sidebar-nav ul {
-        display: none;
-    }
-
-    .sidebar-nav .visible {
-      display: block;
-    }
-</style>
-
 <script>
 
 /*

--- a/src/_includes/sidebar.njk
+++ b/src/_includes/sidebar.njk
@@ -65,8 +65,11 @@
 </style>
 
 <script>
-let activeListItem = document.querySelector('.sidebar-nav .active');
 
+/*
+ * Step 1: Hide elements in the sidebar that is unrelated to the currently shown page (marked with class name "active").
+ */
+let activeListItem = document.querySelector('.sidebar-nav .active');
 if (activeListItem) {
   activeListItem.querySelector(':scope > ul') ? activeListItem.querySelector(':scope > ul').style.display = 'block' : null;
 
@@ -80,4 +83,14 @@ if (activeListItem) {
 } else {
   document.querySelector('.sidebar-nav > li > ul').style.display = 'block';
 }
+
+/*
+ * Step 2: Decorate menu items that have children with an indicator
+ */
+const collapsibleMenuItems = document.querySelectorAll('.sidebar-nav a + ul');
+collapsibleMenuItems.forEach(node => {
+  if (node.previousElementSibling) {
+    node.previousElementSibling.insertAdjacentHTML('beforeend', ' &raquo;');
+  }
+});
 </script>

--- a/src/_includes/sidebar.njk
+++ b/src/_includes/sidebar.njk
@@ -53,3 +53,31 @@
   {% endif %}
   {{ navPages | eleventyNavigationToHtml({listClass: "sidebar-nav", activeListItemClass: "active", activeKey: eleventyNavigation.key}) | safe }}
 </nav>
+
+<style>
+    .sidebar-nav ul {
+        display: none;
+    }
+
+    .sidebar-nav .visible {
+      display: block;
+    }
+</style>
+
+<script>
+let activeListItem = document.querySelector('.sidebar-nav .active');
+
+if (activeListItem) {
+  activeListItem.querySelector(':scope > ul') ? activeListItem.querySelector(':scope > ul').style.display = 'block' : null;
+
+  // Traverse updwards from the active and show lists
+  while (activeListItem.parentNode && activeListItem.parentNode.classList.contains('sidebar-nav') === false) {
+    activeListItem = activeListItem.parentNode;
+    if (activeListItem.tagName = 'li') {
+      activeListItem.classList.add('visible');
+    }
+  }
+} else {
+  document.querySelector('.sidebar-nav > li > ul').style.display = 'block';
+}
+</script>

--- a/src/_sass/style.scss
+++ b/src/_sass/style.scss
@@ -64,7 +64,7 @@ iframe {
 
 .grid-wrapper {
     display: grid;
-    grid-template-columns: 300px 1fr;
+    grid-template-columns: 308px 1fr;
     grid-template-rows: 80px auto auto;
     grid-template-areas:
         "header header"

--- a/src/_sass/style.scss
+++ b/src/_sass/style.scss
@@ -254,15 +254,21 @@ a {
         @include font.color(base);
     }
 
-    &-nav ul {
-        /*
-         * As a default, make all lists invisible.
-         * JavaScript will then decide which to show by applying the .visible class.
-         */
-        display: none;
+    &-nav {
+        ul {
+            /*
+             * As a default, make all lists invisible.
+             * JavaScript will then decide which to show by applying the .visible class.
+             */
+            display: none;
 
-        &.visible {
-            display: block;
+            &.visible {
+                display: block;
+            }
+        }
+
+        .active > ul {
+            display: block;;
         }
     }
 

--- a/src/_sass/style.scss
+++ b/src/_sass/style.scss
@@ -254,6 +254,17 @@ a {
         @include font.color(base);
     }
 
+    &-nav ul {
+        /*
+         * As a default, make all lists invisible.
+         * JavaScript will then decide which to show by applying the .visible class.
+         */
+        display: none;
+
+        &.visible {
+            display: initial;
+        }
+    }
 
     ul {
         margin: 0;

--- a/src/_sass/style.scss
+++ b/src/_sass/style.scss
@@ -262,7 +262,7 @@ a {
         display: none;
 
         &.visible {
-            display: initial;
+            display: block;
         }
     }
 

--- a/src/assets/sidebar.js
+++ b/src/assets/sidebar.js
@@ -1,0 +1,29 @@
+window.addEventListener('DOMContentLoaded', () => {
+    /*
+     * Step 1: Hide elements in the sidebar that is unrelated to the currently shown page (marked with class name "active").
+     */
+    let activeListItem = document.querySelector('.sidebar-nav .active');
+    if (activeListItem) {
+        activeListItem.querySelector(':scope > ul') ? activeListItem.querySelector(':scope > ul').style.display = 'block' : null;
+
+        // Traverse updwards from the active and show lists
+        while (activeListItem.parentNode && activeListItem.parentNode.classList.contains('sidebar-nav') === false) {
+            activeListItem = activeListItem.parentNode;
+            if (activeListItem.tagName = 'li') {
+                activeListItem.classList.add('visible');
+            }
+        }
+    } else {
+        document.querySelector('.sidebar-nav > li > ul').style.display = 'block';
+    }
+
+    /*
+     * Step 2: Decorate menu items that have children with an indicator
+     */
+    const collapsibleMenuItems = document.querySelectorAll('.sidebar-nav a + ul');
+    collapsibleMenuItems.forEach(node => {
+        if (node.previousElementSibling) {
+            node.previousElementSibling.insertAdjacentHTML('beforeend', ' &raquo;');
+        }
+    });
+});

--- a/src/assets/sidebar.js
+++ b/src/assets/sidebar.js
@@ -11,7 +11,7 @@ window.addEventListener('DOMContentLoaded', () => {
             activeList.querySelector(':scope > ul').style.display = 'block';
         }
 
-        // Traverse updwards from the active list and reveal the lists
+        // Traverse upwards from the active list and reveal the lists
         while (activeList.parentNode && activeList.parentNode.classList.contains('sidebar-nav') === false) {
             activeList = activeList.parentNode;
             if (activeList.tagName = 'li') {

--- a/src/assets/sidebar.js
+++ b/src/assets/sidebar.js
@@ -1,12 +1,15 @@
+/*
+ * Script to collapse irrelevant menus in the sidebar.
+ */
 window.addEventListener('DOMContentLoaded', () => {
     /*
-     * Step 1: Hide elements in the sidebar that is unrelated to the currently shown page (marked with class name "active").
+     * Hide elements in the sidebar that is unrelated to the currently shown page (marked with class name "active").
      */
     let activeListItem = document.querySelector('.sidebar-nav .active');
     if (activeListItem) {
         activeListItem.querySelector(':scope > ul') ? activeListItem.querySelector(':scope > ul').style.display = 'block' : null;
 
-        // Traverse updwards from the active and show lists
+        // Traverse updwards from the active list and reveal the lists
         while (activeListItem.parentNode && activeListItem.parentNode.classList.contains('sidebar-nav') === false) {
             activeListItem = activeListItem.parentNode;
             if (activeListItem.tagName = 'li') {
@@ -18,11 +21,11 @@ window.addEventListener('DOMContentLoaded', () => {
     }
 
     /*
-     * Step 2: Decorate menu items that have children with an indicator
+     * Decorate menu items that have children with an indicator
      */
     const collapsibleMenuItems = document.querySelectorAll('.sidebar-nav a + ul');
     collapsibleMenuItems.forEach(node => {
-        if (node.previousElementSibling) {
+        if (node.previousElementSibling && node.previousElementSibling.tagName.toLowerCase() === 'a') {
             node.previousElementSibling.insertAdjacentHTML('beforeend', ' &raquo;');
         }
     });

--- a/src/assets/sidebar.js
+++ b/src/assets/sidebar.js
@@ -7,10 +7,6 @@ window.addEventListener('DOMContentLoaded', () => {
      */
     let activeList = document.querySelector('.sidebar-nav .active');
     if (activeList) {
-        if (activeList.querySelector(':scope > ul')) {
-            activeList.querySelector(':scope > ul').style.display = 'block';
-        }
-
         // Traverse upwards from the active list and reveal the lists
         while (activeList.parentNode && activeList.parentNode.classList.contains('sidebar-nav') === false) {
             activeList = activeList.parentNode;

--- a/src/assets/sidebar.js
+++ b/src/assets/sidebar.js
@@ -3,21 +3,24 @@
  */
 window.addEventListener('DOMContentLoaded', () => {
     /*
-     * Hide elements in the sidebar that is unrelated to the currently shown page (marked with class name "active").
+     * Hide lists in the sidebar that are unrelated to the currently shown page (marked with class name "active").
      */
-    let activeListItem = document.querySelector('.sidebar-nav .active');
-    if (activeListItem) {
-        activeListItem.querySelector(':scope > ul') ? activeListItem.querySelector(':scope > ul').style.display = 'block' : null;
+    let activeList = document.querySelector('.sidebar-nav .active');
+    if (activeList) {
+        if (activeList.querySelector(':scope > ul')) {
+            activeList.querySelector(':scope > ul').style.display = 'block';
+        }
 
         // Traverse updwards from the active list and reveal the lists
-        while (activeListItem.parentNode && activeListItem.parentNode.classList.contains('sidebar-nav') === false) {
-            activeListItem = activeListItem.parentNode;
-            if (activeListItem.tagName = 'li') {
-                activeListItem.classList.add('visible');
+        while (activeList.parentNode && activeList.parentNode.classList.contains('sidebar-nav') === false) {
+            activeList = activeList.parentNode;
+            if (activeList.tagName = 'li') {
+                activeList.classList.add('visible');
             }
         }
     } else {
-        document.querySelector('.sidebar-nav > li > ul').style.display = 'block';
+        // In case no list is active, set the first one as visible
+        document.querySelector('.sidebar-nav > li:first-child > ul').style.display = 'block';
     }
 
     /*


### PR DESCRIPTION
A pure JavaScript+CSS solution to hide submenus in the navigation sidebar that are irrelevant to the current page.

Also, increasing the width of the sidebar to accommodate for the expand indicator.