### PR TITLE
Collapsible sidebar on restructure branch

### DIFF
--- a/src/_includes/head.njk
+++ b/src/_includes/head.njk
@@ -19,6 +19,7 @@
         />
         <link rel="stylesheet" href="{{ '/assets/syntax-theme.css' | url }}" />
 
+        <script src="{{ '/assets/sidebar.js' | url }}"></script>
         <script
             type="module"
             src="https://unpkg.com/@mapsindoors/components@7.2.1/dist/mi-components/mi-components.esm.js"

--- a/src/_sass/style.scss
+++ b/src/_sass/style.scss
@@ -254,6 +254,23 @@ a {
         @include font.color(base);
     }
 
+    &-nav {
+        ul {
+            /*
+             * As a default, make all lists invisible.
+             * JavaScript will then decide which to show by applying the .visible class.
+             */
+            display: none;
+
+            &.visible {
+                display: block;
+            }
+        }
+
+        .active > ul {
+            display: block;;
+        }
+    }
 
     ul {
         margin: 0;

--- a/src/assets/sidebar.js
+++ b/src/assets/sidebar.js
@@ -1,0 +1,31 @@
+/*
+ * Script to collapse irrelevant menus in the sidebar.
+ */
+window.addEventListener('DOMContentLoaded', () => {
+    /*
+     * Hide lists in the sidebar that are unrelated to the currently shown page (marked with class name "active").
+     */
+    let activeList = document.querySelector('.sidebar-nav .active');
+    if (activeList) {
+        // Traverse upwards from the active list and reveal the lists
+        while (activeList.parentNode && activeList.parentNode.classList.contains('sidebar-nav') === false) {
+            activeList = activeList.parentNode;
+            if (activeList.tagName = 'li') {
+                activeList.classList.add('visible');
+            }
+        }
+    } else {
+        // In case no list is active, set the first one as visible
+        document.querySelector('.sidebar-nav > li:first-child > ul').style.display = 'block';
+    }
+
+    /*
+     * Decorate menu items that have children with an indicator
+     */
+    const collapsibleMenuItems = document.querySelectorAll('.sidebar-nav a + ul');
+    collapsibleMenuItems.forEach(node => {
+        if (node.previousElementSibling && node.previousElementSibling.tagName.toLowerCase() === 'a') {
+            node.previousElementSibling.insertAdjacentHTML('beforeend', ' &raquo;');
+        }
+    });
+});


### PR DESCRIPTION
Implement logic to hide parts of the sidebar menu that are unrelated to the currently active page. It will decorate menu items with children with an indicator.

It is the same implementation as https://github.com/MapsPeople/docs/pull/812
