### PR TITLE
Anonymize IP collection

### DIFF
--- a/src/_includes/analytics.njk
+++ b/src/_includes/analytics.njk
@@ -5,5 +5,5 @@
     function gtag() { dataLayer.push(arguments); }
     gtag('js', new Date());
 
-    gtag('config', 'UA-63919776-1');
+    gtag('config', 'UA-63919776-1', { 'anonymize_ip': true });
 </script>


### PR DESCRIPTION
We don't want to collect IP addresses as part of the Google Analytics tracking. I updated the line based on this: https://developers.google.com/analytics/devguides/collection/gtagjs/ip-anonymization