### PR TITLE
Expand "CMS User Roles" description in CMS Documentation

### DIFF
--- a/src/content/cms/index.md
+++ b/src/content/cms/index.md
@@ -56,12 +56,12 @@ There are two main pages in the CMS, "Map" and "Solution Details". The hierarchi
 
 In the CMS there are different levels of users, which has an effect on what you have access to. For example, an "Admin" level user has access to Solution-level settings, whereas an "Editor" primarily has access to create and edit Locations on the Map. This documentation is written with an **Admin** user level in mind.
 
+* **Admin** - Administrators have full access to all menu points and options shown in the list above.
 * **Editor** - Editors can create new Locations, edit and delete existing Locations.
-* **Admin** - Administrators have editor rights and have access to further settings in the CMS
 
 ## Interface Overview
 
-If you prefer to recieve the following information in video format, watch the video below!
+If you prefer to receive the following information in video format, watch the video below!
 
 <iframe width="480" height="300" src="https://www.youtube-nocookie.com/embed/0boSj6X8Ces" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 

--- a/src/content/cms/index.md
+++ b/src/content/cms/index.md
@@ -57,7 +57,22 @@ There are two main pages in the CMS, "Map" and "Solution Details". The hierarchi
 In the CMS there are different levels of users, which has an effect on what you have access to. For example, an "Admin" level user has access to Solution-level settings, whereas an "Editor" primarily has access to create and edit Locations on the Map. This documentation is written with an **Admin** user level in mind.
 
 * **Administrator** - Administrators have full access to all menu points and options shown in the list above.
-* **Editor** - Editors have more limited access than Administrators, being limited to creating new Locations, alongside editing and deleting existing Locations.
+* **Editor** - Editors have more limited access than Administrators, being limited to creating new Locations, alongside editing and deleting existing Locations. This gives you access to the following tools:
+  * **Add POI** - Creates a Point of Interest where you click on the Map. Afterwards it opens an editor where Location details can be adjusted.
+  * **Add Area** - Creates an Area by clicking on the Map to create corners of a polygon. Afterwards it opens an editor where Area details can be adjusted.
+  * All Display Filter options.
+  * The following Location Editor Options:
+    * **Type** - Locations must have a Type applied, which can be set in the Location details editor. When creating a new Location some settings are inherited from the selected Type e.g. Name and Icon. You can always change the inherited settings to something else if necessary.
+    * **Name & Description** - Type in the name of your Location, and a Description. Entering it in the default language is mandatory, but you also have options to enter it in alternative languages.
+    * **Categories** - Add which, if any, Categories this Location belongs to.
+    * **External ID** - You can define an External ID that a Location should use alongside its internal ID.
+    * **Area** - Choose the rotation of the Area the Location covers.
+    * **Search** - Other search terms that can be searched, and still return this Location, even if it is not a match to the Name, Type or Category.
+    * **Restrictions** - Determine which, if any, App User Role Restrictions this Location should be subject to.
+    * **Visibility** - If your Location is only displayed and searchable for a given time period, you can define that here.
+    * **Image** - Assign an image to be used for this Location.
+    * **Custom Properties** - MapsIndoors supports Custom Properties, defined by key-value pairs.
+    * **Details** - Select which Building and Floor this Location should belong to.
 
 ## Interface Overview
 

--- a/src/content/cms/index.md
+++ b/src/content/cms/index.md
@@ -56,8 +56,8 @@ There are two main pages in the CMS, "Map" and "Solution Details". The hierarchi
 
 In the CMS there are different levels of users, which has an effect on what you have access to. For example, an "Admin" level user has access to Solution-level settings, whereas an "Editor" primarily has access to create and edit Locations on the Map. This documentation is written with an **Admin** user level in mind.
 
-* **Admin** - Administrators have full access to all menu points and options shown in the list above.
-* **Editor** - Editors can create new Locations, edit and delete existing Locations.
+* **Administrator** - Administrators have full access to all menu points and options shown in the list above.
+* **Editor** - Editors have more limited access than Administrators, being limited to creating new Locations, alongside editing and deleting existing Locations.
 
 ## Interface Overview
 


### PR DESCRIPTION
I've expanded upon the descriptions of the Editor and Admin roles, to better describe exactly what the different capabilities of the roles are.