### PR TITLE
Add/latest version disclaimer

### DIFF
--- a/src/content/getting-started/android/new-project.md
+++ b/src/content/getting-started/android/new-project.md
@@ -104,6 +104,6 @@ Put those lines in your proguard-rules files:
 
 Sync your project with gradle.
 
-> PLEASE NOTE - This "Getting Started" guide is created using a specific version of the SDK. When moving beyond the "Getting Started" guide, please be sure to download the latest version of the SDK!
+> This "Getting Started" guide is created using a specific version of the SDK. When moving beyond the "Getting Started" guide, please be sure to use the latest version of the SDK.
 
 <p class="next-article"><a class="mi-button mi-button--outline" href="{{ site.url }}/content/getting-started/android/map/">Next up: Show a map</a></p>

--- a/src/content/getting-started/android/new-project.md
+++ b/src/content/getting-started/android/new-project.md
@@ -104,6 +104,6 @@ Put those lines in your proguard-rules files:
 
 Sync your project with gradle.
 
-> PLEASE NOTE - This "Getting Started" guide is created using a version of the SDK that is known to be fully stable and functioning. When moving beyond the "Getting Started" guide, please be sure to download the latest version of the SDK to ensure the features described in our documentation are reflected in SDK you are using!
+> PLEASE NOTE - This "Getting Started" guide is created using a specific version of the SDK. When moving beyond the "Getting Started" guide, please be sure to download the latest version of the SDK!
 
 <p class="next-article"><a class="mi-button mi-button--outline" href="{{ site.url }}/content/getting-started/android/map/">Next up: Show a map</a></p>

--- a/src/content/getting-started/android/new-project.md
+++ b/src/content/getting-started/android/new-project.md
@@ -104,4 +104,6 @@ Put those lines in your proguard-rules files:
 
 Sync your project with gradle.
 
+> PLEASE NOTE - This "Getting Started" guide is created using a version of the SDK that is known to be fully stable and functioning. When moving beyond the "Getting Started" guide, please be sure to download the latest version of the SDK to ensure the features described in our documentation are reflected in SDK you are using!
+
 <p class="next-article"><a class="mi-button mi-button--outline" href="{{ site.url }}/content/getting-started/android/map/">Next up: Show a map</a></p>

--- a/src/content/getting-started/ios/set-up-your-environment.md
+++ b/src/content/getting-started/ios/set-up-your-environment.md
@@ -92,7 +92,7 @@ When the Google Maps installation is completed, go through these steps to instal
 </mi-tab-panel>
 </mi-tabs>
 
-> PLEASE NOTE - This "Getting Started" guide is created using a specific version of the SDK. When moving beyond the "Getting Started" guide, please be sure to download the latest version of the SDK!
+> This "Getting Started" guide is created using a specific version of the SDK. When moving beyond the "Getting Started" guide, please be sure to use the latest version of the SDK.
 
 ## Adding API Credentials
 

--- a/src/content/getting-started/ios/set-up-your-environment.md
+++ b/src/content/getting-started/ios/set-up-your-environment.md
@@ -92,7 +92,7 @@ When the Google Maps installation is completed, go through these steps to instal
 </mi-tab-panel>
 </mi-tabs>
 
-> PLEASE NOTE - This "Getting Started" guide is created using a version of the SDK that is known to be fully stable and functioning. When moving beyond the "Getting Started" guide, please be sure to download the latest version of the SDK to ensure the features described in our documentation are reflected in SDK you are using!
+> PLEASE NOTE - This "Getting Started" guide is created using a specific version of the SDK. When moving beyond the "Getting Started" guide, please be sure to download the latest version of the SDK!
 
 ## Adding API Credentials
 

--- a/src/content/getting-started/ios/set-up-your-environment.md
+++ b/src/content/getting-started/ios/set-up-your-environment.md
@@ -92,6 +92,8 @@ When the Google Maps installation is completed, go through these steps to instal
 </mi-tab-panel>
 </mi-tabs>
 
+> PLEASE NOTE - This "Getting Started" guide is created using a version of the SDK that is known to be fully stable and functioning. When moving beyond the "Getting Started" guide, please be sure to download the latest version of the SDK to ensure the features described in our documentation are reflected in SDK you are using!
+
 ## Adding API Credentials
 
 Open back up the project and navigate to the file `AppDelegate.swift`.

--- a/src/content/getting-started/web/map.md
+++ b/src/content/getting-started/web/map.md
@@ -17,7 +17,7 @@ eleventyNavigation:
 <!-- Overview -->
 {% include "src/content/shared/async-notice.md" %}
 
-> PLEASE NOTE - This "Getting Started" guide is created using a version of the SDK that is known to be fully stable and functioning. When moving beyond the "Getting Started" guide, please be sure to download the latest version of the SDK to ensure the features described in our documentation are reflected in SDK you are using!
+> PLEASE NOTE - This "Getting Started" guide is created using a specific version of the SDK. When moving beyond the "Getting Started" guide, please be sure to download the latest version of the SDK!
 
 <mi-tabs>
 <mi-tab label="Google Maps - Manually" tab-for="gm-manually"></mi-tab>

--- a/src/content/getting-started/web/map.md
+++ b/src/content/getting-started/web/map.md
@@ -17,7 +17,7 @@ eleventyNavigation:
 <!-- Overview -->
 {% include "src/content/shared/async-notice.md" %}
 
-> PLEASE NOTE - This "Getting Started" guide is created using a specific version of the SDK. When moving beyond the "Getting Started" guide, please be sure to download the latest version of the SDK!
+> This "Getting Started" guide is created using a specific version of the SDK. When moving beyond the "Getting Started" guide, please be sure to use the latest version of the SDK.
 
 <mi-tabs>
 <mi-tab label="Google Maps - Manually" tab-for="gm-manually"></mi-tab>

--- a/src/content/getting-started/web/map.md
+++ b/src/content/getting-started/web/map.md
@@ -17,6 +17,8 @@ eleventyNavigation:
 <!-- Overview -->
 {% include "src/content/shared/async-notice.md" %}
 
+> PLEASE NOTE - This "Getting Started" guide is created using a version of the SDK that is known to be fully stable and functioning. When moving beyond the "Getting Started" guide, please be sure to download the latest version of the SDK to ensure the features described in our documentation are reflected in SDK you are using!
+
 <mi-tabs>
 <mi-tab label="Google Maps - Manually" tab-for="gm-manually"></mi-tab>
 <mi-tab label="Google Maps - MI Components" tab-for="gm-components"></mi-tab>

--- a/src/content/getting-started/web/new-project.md
+++ b/src/content/getting-started/web/new-project.md
@@ -41,4 +41,6 @@ eleventyNavigation:
 
 Both here, and in future code examples, you will always be able to see which of two files the code should go in, by looking at the first line, where the name of the file is written.
 
+> PLEASE NOTE - This "Getting Started" guide is created using a version of the SDK that is known to be fully stable and functioning. When moving beyond the "Getting Started" guide, please be sure to download the latest version of the SDK to ensure the features described in our documentation are reflected in SDK you are using!
+
 <p class="next-article"><a class="mi-button mi-button--outline" href="{{ site.url }}/content/getting-started/web/map/">Next up: Show a map</a></p>

--- a/src/content/getting-started/web/new-project.md
+++ b/src/content/getting-started/web/new-project.md
@@ -41,6 +41,4 @@ eleventyNavigation:
 
 Both here, and in future code examples, you will always be able to see which of two files the code should go in, by looking at the first line, where the name of the file is written.
 
-> PLEASE NOTE - This "Getting Started" guide is created using a version of the SDK that is known to be fully stable and functioning. When moving beyond the "Getting Started" guide, please be sure to download the latest version of the SDK to ensure the features described in our documentation are reflected in SDK you are using!
-
 <p class="next-article"><a class="mi-button mi-button--outline" href="{{ site.url }}/content/getting-started/web/map/">Next up: Show a map</a></p>


### PR DESCRIPTION
Added short disclaimers where relevant to each of the Getting Started guides - Should provide some more clarity regarding why we choose to use an older version of the SDK for Getting Started, but reminding users ot upgrade when advancing beyond.