### PR TITLE
Update/standard app to template app

### DIFF
--- a/src/content/cms/index.md
+++ b/src/content/cms/index.md
@@ -194,7 +194,7 @@ Here you can change the title of your app.
 
 The API Keys used to make your MapsIndoors Solution consist of random combinations of letters and numbers. Here, you can assign them an Alias to make it easier to remember.
 
-> NOTE: Do not set an Alias if you want to make it more difficult to find and load your MapsIndoors data in a regular app. In that case, you should only load the data with an API key.
+> NOTE: Do not set an Alias if you want to make it more difficult to find and load your MapsIndoors data. In that case, you should only load the data with an API key.
 
 ![solution-details-app-user-roles](/assets/cms/interface-overview/Solution_Details_App_User_Roles_V2.png)
 

--- a/src/content/cms/index.md
+++ b/src/content/cms/index.md
@@ -194,7 +194,7 @@ Here you can change the title of your app.
 
 The API Keys used to make your MapsIndoors Solution consist of random combinations of letters and numbers. Here, you can assign them an Alias to make it easier to remember.
 
-> NOTE: Do not set an Alias if you want to make it more difficult to find and load your MapsIndoors data in a standard app. In that case, you can only load the data with an API key.
+> NOTE: Do not set an Alias if you want to make it more difficult to find and load your MapsIndoors data in a regular app. In that case, you should only load the data with an API key.
 
 ![solution-details-app-user-roles](/assets/cms/interface-overview/Solution_Details_App_User_Roles_V2.png)
 

--- a/src/content/getting-started/android/mapsindoors-template.md
+++ b/src/content/getting-started/android/mapsindoors-template.md
@@ -8,7 +8,7 @@ eleventyNavigation:
   order: 9999
 ---
 
-The **MapsIndoors Template** is both a full app and plug-and-play code for you to integrate basic usage of MapsIndoors, containing search and directions functionalities, in your existing app. If you just want to get started with a simple solution with no customisation, this should fulfil your needs. Going through this guide will also teach you some principles on how MapsIndoors interacts with an app, and is a natural next step after the "Getting Started" guides.
+The **MapsIndoors Template** is a downloadable starting point for you to integrate basic usage of MapsIndoors, containing search and directions functionalities, into your existing app. If you just want to get started with a simple solution with no customisation, this should fulfil your needs. Going through this guide will also teach you some principles on how MapsIndoors interacts with an app, and is a natural next step after the "Getting Started" guides.
 
 If you need more customisation you can implementing your own solution using the documentation found [here]({{site.url}}/content/map/), or modify this code as needed.
 

--- a/src/content/getting-started/ios/mapsindoors-template.md
+++ b/src/content/getting-started/ios/mapsindoors-template.md
@@ -8,7 +8,7 @@ eleventyNavigation:
   order: 9999
 ---
 
-The **MapsIndoors Template** is both a full app and plug-and-play code for you to integrate basic usage of MapsIndoors, containing search and directions functionalities, in your existing app. If you just want to get started with a simple solution with no customisation, this should fulfil your needs. Going through this guide will also teach you some principles on how MapsIndoors interacts with an app, and is a natural next step after the "Getting Started" guides.
+The **MapsIndoors Template** is a downloadable starting point for you to integrate basic usage of MapsIndoors, containing search and directions functionalities, into your existing app. If you just want to get started with a simple solution with no customisation, this should fulfil your needs. Going through this guide will also teach you some principles on how MapsIndoors interacts with an app, and is a natural next step after the "Getting Started" guides.
 
 If you need more customisation you can implementing your own solution using the documentation found [here]({{site.url}}/content/map/), or modify this code as needed.
 

--- a/src/content/map/various/configure-menu-with-appconfig.md
+++ b/src/content/map/various/configure-menu-with-appconfig.md
@@ -7,7 +7,7 @@ eleventyNavigation:
   order: 420
 ---
 <!-- lets divulge the general information and why this is useful -->
-`AppConfig` primarily contains elements that are used by the standard apps, but it also contains some elements that are useful for any app developer using the SDK. This guide will showcase how to use `AppConfig` to create a menu of location categories.
+`AppConfig` contains elements that are useful for any app developer using the SDK. This guide will showcase how to use `AppConfig` to create a menu of location categories.
 
 <!-- The code can be found here -->
 > This guide uses code from the "Getting Started" guide. If you have not completed it yet, it is <b>highly recommended</b> to complete it in order to achieve a better understanding of the MapsIndoors SDK. The guide can be found [here]({{ site.url }}/content/getting-started/android/). If you just want to follow this guide, the getting started code can be found here for [java](https://github.com/MapsPeople/MapsIndoors-Getting-Started-Android)/[kotlin](https://github.com/MapsPeople/MapsIndoors-Getting-Started-Android-Kotlin).

--- a/src/content/various/authentication/index.md
+++ b/src/content/various/authentication/index.md
@@ -9,7 +9,7 @@ eleventyNavigation:
 
 MapsIndoors Auth is handled in two ways:
 
-* API keys - This is how standard apps and custom apps built on top of the SDKs authorize by default,
+* API keys - This is how apps built on top of the SDKs authorize by default,
 * MapsIndoors Auth server - This is how the MapsIndoors CMS authorizes, as well as apps accessing secured solutions.
 
 The MapsIndoors Auth server is located at [https://auth.mapsindoors.com](https://auth.mapsindoors.com) - including [SSO page](https://auth.mapsindoors.com/login) and [OIDC metadata](https://auth.mapsindoors.com/.well-known/openid-configuration).

--- a/src/product/index.md
+++ b/src/product/index.md
@@ -38,13 +38,13 @@ The SDKs enable you to build your own custom app on top of, or as an integral pa
 
 The MapsIndoors SDKs are the engines that ensure your users can view, navigate, and receive important information about the space around them. Common use cases include getting directions from an outdoor location to your indoor locations, searching your indoor locations, showing the relevant information for a specific location, exposing dynamic data for a location, and more. An exhaustive list of features within the SDKs can be found in the reference documentation for each platform.
 
-## Standard Apps
+## MapsIndoors Templates
 
-MapsIndoors Standard Apps are built on top of the SDKs and visualize some of the SDK capabilities. The Standard Apps are plug-and-play and provide a good basic indoor navigation app. Most clients choose to only use the Standard Apps for testing or demo purposes, and use the SDKs to create a completely customized experience for their users.
+The MapsIndoors Template is both a full app and plug-and-play code for you to integrate basic usage of MapsIndoors, containing search and directions functionalities, in your existing app. If you just want to get started with a simple solution with no customisation, this should fulfil your needs. Most clients choose to only use the Template for testing or demo purposes, and use the SDKs to create a completely customized experience for their users.
 
 ![WebApp](/assets/product/webApp.png)
 
-The MapsIndoors Standard App suite also includes a plug-and-play Kiosk web app. This browser-based app can run on an information stand and help one-time users of a facility find their way without needing to install an app.
+For web development, instead of the MapsIndoors Template, a MapsIndoors "Standard App" with similar functionality also includes a plug-and-play Kiosk web app. This browser-based app can run on an information stand and help one-time users of a facility find their way without needing to install an app.
 
 ![Kiosk](/assets/product/Kiosk1.png)
 

--- a/src/product/index.md
+++ b/src/product/index.md
@@ -44,7 +44,7 @@ The MapsIndoors Template is both a full app and plug-and-play code for you to in
 
 ![WebApp](/assets/product/webApp.png)
 
-For web development, instead of the MapsIndoors Template, a MapsIndoors "Standard App" with similar functionality also includes a plug-and-play Kiosk web app. This browser-based app can run on an information stand and help one-time users of a facility find their way without needing to install an app.
+For web development, instead of the MapsIndoors Template, a MapsIndoors "Showcase App" with similar functionality, as well as a plug-and-play Kiosk web app exists.
 
 ![Kiosk](/assets/product/Kiosk1.png)
 

--- a/src/product/index.md
+++ b/src/product/index.md
@@ -40,7 +40,7 @@ The MapsIndoors SDKs are the engines that ensure your users can view, navigate, 
 
 ## MapsIndoors Templates
 
-The MapsIndoors Template is both a full app and plug-and-play code for you to integrate basic usage of MapsIndoors, containing search and directions functionalities, in your existing app. If you just want to get started with a simple solution with no customisation, this should fulfil your needs. Most clients choose to only use the Template for testing or demo purposes, and use the SDKs to create a completely customized experience for their users.
+The MapsIndoors Template is a downloadable starting point for you to integrate basic usage of MapsIndoors, containing search and directions functionalities, into your existing app. If you just want to get started with a simple solution with no customisation, this should fulfil your needs. Most clients choose to only use the Template for testing or demo purposes, and use the SDKs to create a completely customized experience for their users.
 
 ![WebApp](/assets/product/webApp.png)
 


### PR DESCRIPTION
We're moving away from advertising our Standard/PoC apps to customers, at least on mobile, and replacing it with our MapsIndoors Templates. Have changed a number of files to reflect this. Initially, it seems that it was also intended to change code samples involving the standard apps, but I don't seem to be able to find any.